### PR TITLE
cookbook: fix useradd syntax and line up with theo-agent/installation.rst

### DIFF
--- a/docs/setup/cookbook.rst
+++ b/docs/setup/cookbook.rst
@@ -140,9 +140,10 @@ You need to create a system user:
 
 ::
 
-    sudo useradd --comment 'Theo Agent' \
-        --create-home /var/cache/theo-agent \
+    sudo useradd \
+        --comment 'Theo Agent' \
         --shell /bin/false \
+        --system \
         theo-agent
 
 Configure


### PR DESCRIPTION
Suggested command fails due to a syntax error: --create-home option does not accept arguments while /var/cache/theo-agent is passed. Moreover we have different commands for the same purpose here and in theo-agent/installation.rst then line them up to a common syntax for clarity.

fixes #3